### PR TITLE
fix runs-on and admin_password

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   linters:
     name: 'Terraform Linters'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     defaults:
       run:
         shell: bash
@@ -69,7 +69,7 @@ jobs:
           download_external_modules: false
   semver:
     name: 'Set code version tag'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     needs:

--- a/examples/one-group/main.tf
+++ b/examples/one-group/main.tf
@@ -25,8 +25,7 @@ module "opensearch" {
   environment             = "PRESTABLE"
   network_id              = module.network.vpc_id
   folder_id               = data.yandex_client_config.client.folder_id
-  generate_admin_password = false
-  admin_password          = "super-password"
+  generate_admin_password = true
 
   opensearch_nodes = {
     group0 = {

--- a/examples/one-group/outputs.tf
+++ b/examples/one-group/outputs.tf
@@ -1,0 +1,5 @@
+output "admin_password" {
+  description = "OpenSearch cluster admin password"
+  value       = module.opensearch.admin_password
+  sensitive   = true
+}


### PR DESCRIPTION
fix admin password
```
│ Error: Failed to Create resource
│ 
│   with module.opensearch.yandex_mdb_opensearch_cluster.main,
│   on ../../main.tf line 8, in resource "yandex_mdb_opensearch_cluster" "main":
│    8: resource "yandex_mdb_opensearch_cluster" "main" {
│ 
│ Error while requesting API to create OpenSearch cluster: client-request-id = b5cff701-6387-4010-9ae2-816a7049b94a client-trace-id =
│ 7c199679-441f-4c49-b460-4008dc116871 rpc error: code = InvalidArgument desc = password must contain at least 3 of 4 different character classes: uppercase
│ letters, lowercase letters, digits and special characters
╵
```