### PR TITLE
Добавлены новые outputs для кластера OpenSearch

### DIFF
--- a/examples/one-group/outputs.tf
+++ b/examples/one-group/outputs.tf
@@ -3,3 +3,36 @@ output "admin_password" {
   value       = module.opensearch.admin_password
   sensitive   = true
 }
+
+output "cluster_id" {
+  description = "ID of the OpenSearch cluster"
+  value       = module.opensearch.cluster_id
+}
+
+output "cluster_health" {
+  description = "Health status of the OpenSearch cluster"
+  value       = module.opensearch.cluster_health
+}
+
+output "cluster_status" {
+  description = "Status of the OpenSearch cluster"
+  value       = module.opensearch.cluster_status
+}
+
+output "cluster_created_at" {
+  description = "Creation timestamp of the OpenSearch cluster"
+  value       = module.opensearch.cluster_created_at
+}
+
+output "hosts" {
+  description = "List of OpenSearch cluster hosts"
+  value       = module.opensearch.hosts
+}
+
+output "dashboard_fqdns" {
+  description = "FQDNs of OpenSearch Dashboard nodes"
+  value = [
+    for host in module.opensearch.dashboard_fqdns :
+    host.fqdn if host.type == "DASHBOARDS"
+  ]
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,38 @@
 output "admin_password" {
   description = "OpenSearch cluster admin password"
   value       = var.generate_admin_password ? random_password.admin_password[0].result : var.admin_password
+  sensitive   = true
+}
+
+output "cluster_id" {
+  description = "ID of the OpenSearch cluster"
+  value       = yandex_mdb_opensearch_cluster.main.id
+}
+
+output "cluster_health" {
+  description = "Health status of the OpenSearch cluster"
+  value       = yandex_mdb_opensearch_cluster.main.health
+}
+
+output "cluster_status" {
+  description = "Status of the OpenSearch cluster"
+  value       = yandex_mdb_opensearch_cluster.main.status
+}
+
+output "cluster_created_at" {
+  description = "Creation timestamp of the OpenSearch cluster"
+  value       = yandex_mdb_opensearch_cluster.main.created_at
+}
+
+output "hosts" {
+  description = "List of OpenSearch cluster hosts"
+  value       = yandex_mdb_opensearch_cluster.main.hosts
+}
+
+output "dashboard_fqdns" {
+  description = "FQDNs of OpenSearch Dashboard nodes"
+  value = [
+    for host in yandex_mdb_opensearch_cluster.main.hosts :
+    host.fqdn if host.type == "DASHBOARDS"
+  ]
 }


### PR DESCRIPTION
Добавлены дополнительные выходные переменные для модуля OpenSearch:

- `cluster_id` - идентификатор кластера
- `cluster_health` - статус здоровья кластера  
- `cluster_status` - общий статус кластера
- `cluster_created_at` - время создания кластера
- `hosts` - список хостов кластера
- `dashboard_fqdns` - FQDN узлов OpenSearch Dashboard

Изменения применены как в основном модуле (`outputs.tf`), так и в примере использования (`examples/one-group/outputs.tf`). Все новые outputs используют данные непосредственно из ресурса `yandex_mdb_opensearch_cluster.main`.